### PR TITLE
Feat/point 서비스계층추가

### DIFF
--- a/src/point/dto/index.ts
+++ b/src/point/dto/index.ts
@@ -1,0 +1,2 @@
+export * from './request.dto';
+export * from './response.dto';

--- a/src/point/dto/request.dto.ts
+++ b/src/point/dto/request.dto.ts
@@ -1,0 +1,6 @@
+import { PointBody } from '../point.dto';
+
+/**
+ * 포인트 충전/사용 요청 Body
+ */
+export class PatchPointRequest extends PointBody {}

--- a/src/point/dto/response.dto.ts
+++ b/src/point/dto/response.dto.ts
@@ -1,0 +1,30 @@
+import { PointHistory, TransactionType, UserPoint } from '../point.model';
+
+/**
+ * 유저 포인트 조회 응답 객체
+ */
+export class GetUserPointResponse
+  implements Pick<UserPoint, 'id' | 'point' | 'updateMillis'>
+{
+  constructor(
+    readonly id: number,
+    readonly point: number,
+    readonly updateMillis: number,
+  ) {}
+}
+
+/**
+ * 포인트 히스토리 조회 응답 객체
+ */
+export class GetPointHistoryResponse
+  implements
+    Pick<PointHistory, 'id' | 'userId' | 'type' | 'amount' | 'timeMillis'>
+{
+  constructor(
+    readonly id: number,
+    readonly userId: number,
+    readonly type: TransactionType,
+    readonly amount: number,
+    readonly timeMillis: number,
+  ) {}
+}

--- a/src/point/point.controller.ts
+++ b/src/point/point.controller.ts
@@ -2,21 +2,19 @@ import {
   Body,
   Controller,
   Get,
+  NotFoundException,
   Param,
   Patch,
   ValidationPipe,
 } from '@nestjs/common';
-import { PointHistory, TransactionType, UserPoint } from './point.model';
-import { UserPointTable } from 'src/database/userpoint.table';
-import { PointHistoryTable } from 'src/database/pointhistory.table';
+
 import { PointBody as PointDto } from './point.dto';
+import { PointHistory, UserPoint } from './point.model';
+import { PointServiceUseCase } from './point.service';
 
 @Controller('/point')
 export class PointController {
-  constructor(
-    private readonly userDb: UserPointTable,
-    private readonly historyDb: PointHistoryTable,
-  ) {}
+  constructor(private readonly pointService: PointServiceUseCase) {}
 
   /**
    * TODO - 특정 유저의 포인트를 조회하는 기능을 작성해주세요.
@@ -33,7 +31,8 @@ export class PointController {
   @Get(':id/histories')
   async history(@Param('id') id): Promise<PointHistory[]> {
     const userId = Number.parseInt(id);
-    return [];
+    // return [];
+    throw new NotFoundException('미구현 API 입니다.');
   }
 
   /**
@@ -46,7 +45,8 @@ export class PointController {
   ): Promise<UserPoint> {
     const userId = Number.parseInt(id);
     const amount = pointDto.amount;
-    return { id: userId, point: amount, updateMillis: Date.now() };
+    // return { id: userId, point: amount, updateMillis: Date.now() };
+    throw new NotFoundException('미구현 API 입니다.');
   }
 
   /**
@@ -59,6 +59,7 @@ export class PointController {
   ): Promise<UserPoint> {
     const userId = Number.parseInt(id);
     const amount = pointDto.amount;
-    return { id: userId, point: amount, updateMillis: Date.now() };
+    // return { id: userId, point: amount, updateMillis: Date.now() };
+    throw new NotFoundException('미구현 API 입니다.');
   }
 }

--- a/src/point/point.controller.ts
+++ b/src/point/point.controller.ts
@@ -8,9 +8,12 @@ import {
   ValidationPipe,
 } from '@nestjs/common';
 
-import { PointBody as PointDto } from './point.dto';
-import { PointHistory, UserPoint } from './point.model';
 import { PointServiceUseCase } from './point.service';
+import {
+  GetUserPointResponse,
+  GetPointHistoryResponse,
+  PatchPointRequest,
+} from './dto';
 
 @Controller('/point')
 export class PointController {
@@ -20,7 +23,7 @@ export class PointController {
    * TODO - 특정 유저의 포인트를 조회하는 기능을 작성해주세요.
    */
   @Get(':id')
-  async point(@Param('id') id): Promise<UserPoint> {
+  async point(@Param('id') id): Promise<GetUserPointResponse> {
     const userId = Number.parseInt(id);
     return { id: userId, point: 0, updateMillis: Date.now() };
   }
@@ -29,7 +32,7 @@ export class PointController {
    * TODO - 특정 유저의 포인트 충전/이용 내역을 조회하는 기능을 작성해주세요.
    */
   @Get(':id/histories')
-  async history(@Param('id') id): Promise<PointHistory[]> {
+  async history(@Param('id') id): Promise<GetPointHistoryResponse[]> {
     const userId = Number.parseInt(id);
     // return [];
     throw new NotFoundException('미구현 API 입니다.');
@@ -41,10 +44,11 @@ export class PointController {
   @Patch(':id/charge')
   async charge(
     @Param('id') id,
-    @Body(ValidationPipe) pointDto: PointDto,
-  ): Promise<UserPoint> {
+    @Body(ValidationPipe) pointDto: PatchPointRequest,
+  ): Promise<GetUserPointResponse> {
     const userId = Number.parseInt(id);
     const amount = pointDto.amount;
+
     // return { id: userId, point: amount, updateMillis: Date.now() };
     throw new NotFoundException('미구현 API 입니다.');
   }
@@ -55,8 +59,8 @@ export class PointController {
   @Patch(':id/use')
   async use(
     @Param('id') id,
-    @Body(ValidationPipe) pointDto: PointDto,
-  ): Promise<UserPoint> {
+    @Body(ValidationPipe) pointDto: PatchPointRequest,
+  ): Promise<GetUserPointResponse> {
     const userId = Number.parseInt(id);
     const amount = pointDto.amount;
     // return { id: userId, point: amount, updateMillis: Date.now() };

--- a/src/point/point.module.ts
+++ b/src/point/point.module.ts
@@ -1,9 +1,11 @@
 import { Module } from '@nestjs/common';
 import { PointController } from './point.controller';
 import { DatabaseModule } from 'src/database/database.module';
+import { PointService, PointServiceUseCase } from './point.service';
 
 @Module({
   imports: [DatabaseModule],
   controllers: [PointController],
+  providers: [{ provide: PointServiceUseCase, useClass: PointService }],
 })
 export class PointModule {}

--- a/src/point/point.service.ts
+++ b/src/point/point.service.ts
@@ -1,0 +1,15 @@
+import { Injectable } from '@nestjs/common';
+import { PointHistoryTable } from 'src/database/pointhistory.table';
+import { UserPointTable } from 'src/database/userpoint.table';
+
+export abstract class PointServiceUseCase {}
+
+@Injectable()
+export class PointService extends PointServiceUseCase {
+  constructor(
+    private readonly userDb: UserPointTable,
+    private readonly historyDb: PointHistoryTable,
+  ) {
+    super();
+  }
+}

--- a/src/point/point.service.ts
+++ b/src/point/point.service.ts
@@ -2,8 +2,11 @@ import { Injectable } from '@nestjs/common';
 
 import { PointHistoryTable } from 'src/database/pointhistory.table';
 import { UserPointTable } from 'src/database/userpoint.table';
-import { PointHistory, UserPoint } from './point.model';
-import { PointBody as PointDto } from './dto/request/point.dto';
+import {
+  GetUserPointResponse,
+  GetPointHistoryResponse,
+  PatchPointRequest,
+} from './dto';
 
 export abstract class PointServiceUseCase {
   /**
@@ -25,7 +28,7 @@ export abstract class PointServiceUseCase {
    * - `userId`가 양의 정수가 아니라면 조회에 실패한다.
    * @param userId
    */
-  abstract getPoint(userId: number): Promise<UserPoint>;
+  abstract getPoint(userId: number): Promise<GetUserPointResponse>;
 
   /**
    * 특정 유저의 포인트 충전/이용 내역을 조회합니다.
@@ -46,7 +49,7 @@ export abstract class PointServiceUseCase {
    * - `userId`가 양의 정수가 아니라면 조회에 실패한다.
    * @param userId
    */
-  abstract getHistory(userId: number): Promise<PointHistory[]>;
+  abstract getHistory(userId: number): Promise<GetPointHistoryResponse[]>;
 
   /**
    * 특정 유저의 포인트를 충전합니다.
@@ -72,7 +75,10 @@ export abstract class PointServiceUseCase {
    * @param userId
    * @param pointDto
    */
-  abstract charge(userId: number, pointDto: PointDto): Promise<UserPoint>;
+  abstract charge(
+    userId: number,
+    pointDto: PatchPointRequest,
+  ): Promise<GetUserPointResponse>;
 
   /**
    * 특정 유저의 포인트를 사용합니다.
@@ -97,7 +103,10 @@ export abstract class PointServiceUseCase {
    * @param userId
    * @param pointDto
    */
-  abstract use(userId: number, pointDto: PointDto): Promise<UserPoint>;
+  abstract use(
+    userId: number,
+    pointDto: PatchPointRequest,
+  ): Promise<GetUserPointResponse>;
 }
 
 @Injectable()
@@ -109,22 +118,27 @@ export class PointService extends PointServiceUseCase {
     super();
   }
 
-  override async getPoint(userId: number): Promise<UserPoint> {
+  override async getPoint(userId: number): Promise<GetUserPointResponse> {
     throw new Error('Method not implemented.');
   }
 
-  override async getHistory(userId: number): Promise<PointHistory[]> {
+  override async getHistory(
+    userId: number,
+  ): Promise<GetPointHistoryResponse[]> {
     throw new Error('Method not implemented.');
   }
 
   override async charge(
     userId: number,
-    pointDto: PointDto,
-  ): Promise<UserPoint> {
+    pointDto: PatchPointRequest,
+  ): Promise<GetUserPointResponse> {
     throw new Error('Method not implemented.');
   }
 
-  override async use(userId: number, pointDto: PointDto): Promise<UserPoint> {
+  override async use(
+    userId: number,
+    pointDto: PatchPointRequest,
+  ): Promise<GetUserPointResponse> {
     throw new Error('Method not implemented.');
   }
 }

--- a/src/point/point.service.ts
+++ b/src/point/point.service.ts
@@ -1,8 +1,104 @@
 import { Injectable } from '@nestjs/common';
+
 import { PointHistoryTable } from 'src/database/pointhistory.table';
 import { UserPointTable } from 'src/database/userpoint.table';
+import { PointHistory, UserPoint } from './point.model';
+import { PointBody as PointDto } from './dto/request/point.dto';
 
-export abstract class PointServiceUseCase {}
+export abstract class PointServiceUseCase {
+  /**
+   * 특정 유저의 포인트를 조회합니다.
+   *
+   * ### 행동 분석
+   * 1. HTTP URL Path를 통해 id(userId)를 넘겨 받는다.
+   * 2. id를 검증한다.
+   * 3. 유저의 포인트 현재 포인트를 조회한다.
+   *   - `UserPointTable#selectById` 로직에 의해 유저가 존재하지 않는 경우는 생략한다.
+   * 4. 결과에 맞게 반환한다.
+   *
+   * ### TC
+   * 1. 성공
+   * - 유저의 현재 포인트를 조회한다.
+   * - 최초에 유저의 포인트가 없다면 포인트는 0을 응답한다.
+   * 2. 실패
+   * - `userId`가 존재하지 않으면(null이거나 undefined) 실패힌다.
+   * - `userId`가 양의 정수가 아니라면 조회에 실패한다.
+   * @param userId
+   */
+  abstract getPoint(userId: number): Promise<UserPoint>;
+
+  /**
+   * 특정 유저의 포인트 충전/이용 내역을 조회합니다.
+   *
+   * ### 행동 분석
+   * 1. HTTP URL Path를 통해 id(userId)를 넘겨 받는다.
+   * 2. id를 검증한다.
+   *   - `UserPointTable#selectById` 로직에 의해 유저가 존재하지 않는 경우는 생략한다.
+   * 3. 유저의 포인트 충전/이용 내역을 조회한다.
+   * 4. 결과에 맞게 반환한다.
+   *
+   * ### TC
+   * 1. 성공
+   * - 포인트 충전/이용 내역이을 응답한다.
+   * - 포인트 충전/이용 내역이 없는 유저라면 빈 배열을 응답한다.
+   * 2. 실패
+   * - `userId`가 존재하지 않으면(null이거나 undefined) 실패힌다.
+   * - `userId`가 양의 정수가 아니라면 조회에 실패한다.
+   * @param userId
+   */
+  abstract getHistory(userId: number): Promise<PointHistory[]>;
+
+  /**
+   * 특정 유저의 포인트를 충전합니다.
+   * TODO: 동시성에 대한 처리가 필요하다.
+   *
+   * ### 행동분석
+   * 1. 포인트 충전 파라미터(userId와 충전 금액)를 넘겨 받는다.
+   * 2. 포인트 충전 파라미터를 검증한다.
+   *   - `UserPointTable#selectById` 로직에 의해 유저가 존재하지 않는 경우는 생략한다.
+   * 3. 유저의 현재 포인트를 조회한다.
+   * 4. 조회된 현재 포인트에 충전된 금액을 더해 저장한다.
+   * 5. 포인트 histories에 충전된 내역을 추가한다.
+   * 6. 현재 포인트를 반환한다.
+   *
+   * ### TC
+   * 1. 성공
+   * 2. 실패
+   * - `userId`가 존재하지 않으면(null이거나 undefined) 실패힌다.
+   * - `userId`가 양의 정수가 아니라면 실패한다.
+   * - `pointDto.amount`가 존재하지 않으면(null이거나 undefined) 실패힌다.
+   * - `pointDto.amount`가 양의 정수가 아니라면 실패한다.
+   *
+   * @param userId
+   * @param pointDto
+   */
+  abstract charge(userId: number, pointDto: PointDto): Promise<UserPoint>;
+
+  /**
+   * 특정 유저의 포인트를 사용합니다.
+   * TODO: 동시성에 대한 처리가 필요하다.
+   *
+   * ### 행동분석
+   * 1. 포인트 사용 파라미터(userId와 충전 금액)를 넘겨 받는다.
+   * 2. 포인트 사용 파라미터를 검증한다.
+   *   - `UserPointTable#selectById` 로직에 의해 유저가 존재하지 않는 경우는 생략한다.
+   * 3. 유저의 현재 포인트를 조회한다.
+   * 4. 조회된 현재 포인트에 사용될 금액을 차감해 저장한다.
+   * 5. 포인트 histories에 사용된 내역을 추가한다.
+   * 6. 현재 포인트를 반환한다.
+   *
+   * ### TC
+   * 1. 성공
+   * 2. 실패
+   * - `userId`가 존재하지 않으면(null이거나 undefined) 실패힌다.
+   * - `userId`가 양의 정수가 아니라면 실패한다.
+   * - `pointDto.amount`가 존재하지 않으면(null이거나 undefined) 실패힌다.
+   * - `pointDto.amount`가 양의 정수가 아니라면 실패한다.
+   * @param userId
+   * @param pointDto
+   */
+  abstract use(userId: number, pointDto: PointDto): Promise<UserPoint>;
+}
 
 @Injectable()
 export class PointService extends PointServiceUseCase {
@@ -11,5 +107,24 @@ export class PointService extends PointServiceUseCase {
     private readonly historyDb: PointHistoryTable,
   ) {
     super();
+  }
+
+  override async getPoint(userId: number): Promise<UserPoint> {
+    throw new Error('Method not implemented.');
+  }
+
+  override async getHistory(userId: number): Promise<PointHistory[]> {
+    throw new Error('Method not implemented.');
+  }
+
+  override async charge(
+    userId: number,
+    pointDto: PointDto,
+  ): Promise<UserPoint> {
+    throw new Error('Method not implemented.');
+  }
+
+  override async use(userId: number, pointDto: PointDto): Promise<UserPoint> {
+    throw new Error('Method not implemented.');
   }
 }


### PR DESCRIPTION
# PR Summery

## ✓ PR 타입
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타

## 1️⃣ 작업내용
> [!NOTE] 구체적인 작업 내용을 정리하면 좋습니다.

1. 서비스 계층인 `PointService`를 신규 정의 했습니다. 
   - 로직 구현은 아직이며, 메서드마다 TC 정의를 jsDoc로 했습니다.
   
2. `PointController`는 데이터 계층과 의존을 제거하고, 서비스 계층의 추상 클래스인 `PointServiceUseCase`를 의존하게 했습니다.

3. `PointController`와 `PointService`의 요청 응답 타입을 변경했습니다.
   - `PointService`에서 Domain 객체를 응답하지 않고 DTO를 응답하게 했습니다.
   - 추가적으로 모호하게 사용되던 `PointBody`를 상속하는 `PatchPointRequest` 신규 정의 했습니다.

## 2️⃣ 의사결정 흐름
> [!NOTE] 구현된 코드의 근거나 배경에 대해 설명하면 좋습니다.

![image](https://github.com/user-attachments/assets/52526ed6-03a3-4794-8327-555d14c10cf6)

미션인 서비스 로직 테스트를 진행하기 위해, 기존 코드베이스에서 "3-Tier Architecture" 구조로 변환을 진행했습니다. 
그리고 비즈니스 로직을 구현하고 있는 `PointService`의 각각의 메서드를 구현하기 전에 "TC" 정의를 진행했습니다.
또한 Controller에서 Model을 직접적으로 응답하는 것은 변경된 아키텍처에 맞지 않는다고 판단하여, 서비스에서 컨트롤러로 리턴에 사용될 DTO 객체를 신규 정의했습니다.

응답 DTO의 경우 `UserPoint`를 바로 상속하여 사용할 수 있지만, Model을 필요한 값만 제공하기 위해 사용하는 DTO의 특성에 맞게 명시적으로 필요한 필드만 가져와 정의했습니다.
```typescript
export class GetUserPointResponse
  implements Pick<UserPoint, 'id' | 'point' | 'updateMillis'>
{
  constructor(
    readonly id: number,
    readonly point: number,
    readonly updateMillis: number,
  ) {}
}
```


## 3️⃣ 리뷰 포인트
> [!NOTE] 명확한 리뷰 포인트나, 리뷰 받고 싶은 코드를 참조하면 좋습니다.

1. 변경된 아키텍처 구조를 중점으로 봐주시면 좋겠어요
2. TDD를 진행하기 위해 PointService 메서드에 TC를 정의 했는데 설계가 부합한지 봐주시면 좋겠어요
  - [코드 참고](https://github.com/dbwogus94/hhplus-tdd-nest/compare/feat/point-%EC%84%9C%EB%B9%84%EC%8A%A4%EA%B3%84%EC%B8%B5%EC%B6%94%EA%B0%80?expand=1#diff-318bc2169fadc3950fc485519905e0c235c250b81db504a590c7d095dfc773ebR11)


## 4️⃣ 이슈
> [!NOTE] (optional) 공유하고 싶은 이슈나, 코드가 가진 문제(한계)를 알려주세요.

-

 