### PR TITLE
Feat/point service 조회로직 구현과 단위테스트 수행

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "rxjs": "^7.8.1"
       },
       "devDependencies": {
+        "@faker-js/faker": "^9.0.1",
         "@nestjs/cli": "^10.3.2",
         "@nestjs/schematics": "^10.0.0",
         "@nestjs/testing": "^10.0.0",
@@ -913,6 +914,22 @@
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@faker-js/faker": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-9.0.1.tgz",
+      "integrity": "sha512-4mDeYIgM3By7X6t5E6eYwLAa+2h4DeZDF7thhzIg6XB76jeEvMwadYAMCFJL/R4AnEBcAUO9+gL0vhy3s+qvZA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fakerjs"
+        }
+      ],
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=9.0.0"
       }
     },
     "node_modules/@humanwhocodes/config-array": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "eslint-config-prettier": "^9.0.0",
         "eslint-plugin-prettier": "^5.0.0",
         "jest": "^29.5.0",
+        "jest-mock-extended": "^4.0.0-beta1",
         "jest-sonar-reporter": "^2.0.0",
         "prettier": "^3.0.0",
         "sonarqube-scanner": "^3.3.0",
@@ -5788,6 +5789,20 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/jest-mock-extended": {
+      "version": "4.0.0-beta1",
+      "resolved": "https://registry.npmjs.org/jest-mock-extended/-/jest-mock-extended-4.0.0-beta1.tgz",
+      "integrity": "sha512-MYcI0wQu3ceNhqKoqAJOdEfsVMamAFqDTjoLN5Y45PAG3iIm4WGnhOu0wpMjlWCexVPO71PMoNir9QrGXrnIlw==",
+      "dev": true,
+      "dependencies": {
+        "ts-essentials": "^10.0.2"
+      },
+      "peerDependencies": {
+        "@jest/globals": "^28.0.0 || ^29.0.0",
+        "jest": "^24.0.0 || ^25.0.0 || ^26.0.0 || ^27.0.0 || ^28.0.0 || ^29.0.0",
+        "typescript": "^3.0.0 || ^4.0.0 || ^5.0.0"
+      }
+    },
     "node_modules/jest-pnp-resolver": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
@@ -8246,6 +8261,20 @@
       },
       "peerDependencies": {
         "typescript": ">=4.2.0"
+      }
+    },
+    "node_modules/ts-essentials": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/ts-essentials/-/ts-essentials-10.0.2.tgz",
+      "integrity": "sha512-Xwag0TULqriaugXqVdDiGZ5wuZpqABZlpwQ2Ho4GDyiu/R2Xjkp/9+zcFxL7uzeLl/QCPrflnvpVYyS3ouT7Zw==",
+      "dev": true,
+      "peerDependencies": {
+        "typescript": ">=4.5.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/ts-jest": {

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "eslint-config-prettier": "^9.0.0",
     "eslint-plugin-prettier": "^5.0.0",
     "jest": "^29.5.0",
+    "jest-mock-extended": "^4.0.0-beta1",
     "jest-sonar-reporter": "^2.0.0",
     "prettier": "^3.0.0",
     "sonarqube-scanner": "^3.3.0",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
       "json",
       "ts"
     ],
-    "rootDir": "src",
+    "rootDir": ".",
     "testRegex": ".*\\.spec\\.ts$",
     "transform": {
       "^.+\\.(t|j)s$": "ts-jest"
@@ -72,7 +72,13 @@
     ],
     "coverageDirectory": "../coverage",
     "testEnvironment": "node",
-    "testResultsProcessor": "jest-sonar-reporter"
+    "testResultsProcessor": "jest-sonar-reporter",
+    "moduleNameMapper": {
+      "^src/(.*)$": "<rootDir>/src/$1"
+    },
+    "modulePaths": [
+      "<rootDir>"
+    ]
   },
   "jestSonar": {
     "reportPath": "../coverage",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "rxjs": "^7.8.1"
   },
   "devDependencies": {
+    "@faker-js/faker": "^9.0.1",
     "@nestjs/cli": "^10.3.2",
     "@nestjs/schematics": "^10.0.0",
     "@nestjs/testing": "^10.0.0",

--- a/src/point/dto/response.dto.ts
+++ b/src/point/dto/response.dto.ts
@@ -33,7 +33,13 @@ export class GetPointHistoryResponse
     readonly timeMillis: number,
   ) {}
 
-  static of(history: PointHistory) {
+  static of(history: PointHistory[]): GetPointHistoryResponse[];
+  static of(history: PointHistory): GetPointHistoryResponse;
+  static of(
+    history: PointHistory | PointHistory[],
+  ): GetPointHistoryResponse | GetPointHistoryResponse[] {
+    if (Array.isArray(history)) return history.map((point) => this.of(point));
+
     const { id, userId, type, amount, timeMillis } = history;
     return new GetPointHistoryResponse(id, userId, type, amount, timeMillis);
   }

--- a/src/point/dto/response.dto.ts
+++ b/src/point/dto/response.dto.ts
@@ -11,6 +11,11 @@ export class GetUserPointResponse
     readonly point: number,
     readonly updateMillis: number,
   ) {}
+
+  static of(userPoint: UserPoint) {
+    const { id, point, updateMillis } = userPoint;
+    return new GetUserPointResponse(id, point, updateMillis);
+  }
 }
 
 /**
@@ -27,4 +32,9 @@ export class GetPointHistoryResponse
     readonly amount: number,
     readonly timeMillis: number,
   ) {}
+
+  static of(history: PointHistory) {
+    const { id, userId, type, amount, timeMillis } = history;
+    return new GetPointHistoryResponse(id, userId, type, amount, timeMillis);
+  }
 }

--- a/src/point/point.service.ts
+++ b/src/point/point.service.ts
@@ -7,7 +7,6 @@ import {
   GetPointHistoryResponse,
   PatchPointRequest,
 } from './dto';
-import { TransactionType } from './point.model';
 
 /*
   TODO: 리펙터링
@@ -20,42 +19,12 @@ import { TransactionType } from './point.model';
 export abstract class PointServiceUseCase {
   /**
    * 특정 유저의 포인트를 조회합니다.
-   *
-   * ### 행동 분석
-   * 1. HTTP URL Path를 통해 id(userId)를 넘겨 받는다.
-   * 2. id를 검증한다.
-   * 3. 유저의 포인트 현재 포인트를 조회한다.
-   *   - `UserPointTable#selectById` 로직에 의해 유저가 존재하지 않는 경우는 생략한다.
-   * 4. 결과에 맞게 반환한다.
-   *
-   * ### TC
-   * 1. 성공
-   * - 유저의 현재 포인트를 조회한다.
-   * - 최초에 유저의 포인트가 없다면 포인트는 0을 응답한다.
-   * 2. 실패
-   * - `userId`가 존재하지 않으면(null이거나 undefined) 실패힌다.
-   * - `userId`가 양의 정수가 아니라면 조회에 실패한다.
    * @param userId
    */
   abstract getPoint(userId: number): Promise<GetUserPointResponse>;
 
   /**
    * 특정 유저의 포인트 충전/이용 내역을 조회합니다.
-   *
-   * ### 행동 분석
-   * 1. HTTP URL Path를 통해 id(userId)를 넘겨 받는다.
-   * 2. id를 검증한다.
-   *   - `UserPointTable#selectById` 로직에 의해 유저가 존재하지 않는 경우는 생략한다.
-   * 3. 유저의 포인트 충전/이용 내역을 조회한다.
-   * 4. 결과에 맞게 반환한다.
-   *
-   * ### TC
-   * 1. 성공
-   * - 포인트 충전/이용 내역이을 응답한다.
-   * - 포인트 충전/이용 내역이 없는 유저라면 빈 배열을 응답한다.
-   * 2. 실패
-   * - `userId`가 존재하지 않으면(null이거나 undefined) 실패힌다.
-   * - `userId`가 양의 정수가 아니라면 조회에 실패한다.
    * @param userId
    */
   abstract getHistory(userId: number): Promise<GetPointHistoryResponse[]>;

--- a/src/point/point.service.ts
+++ b/src/point/point.service.ts
@@ -7,6 +7,15 @@ import {
   GetPointHistoryResponse,
   PatchPointRequest,
 } from './dto';
+import { TransactionType } from './point.model';
+
+/*
+  TODO: 리펙터링
+  1. userId 검증은 어떻게 할까? 
+    - 그냥 컨트롤러 Pipe로 해결
+    - param Valdate 정의?
+    - 
+*/
 
 export abstract class PointServiceUseCase {
   /**
@@ -132,7 +141,14 @@ export class PointService extends PointServiceUseCase {
   override async getHistory(
     userId: number,
   ): Promise<GetPointHistoryResponse[]> {
-    throw new Error('Method not implemented.');
+    if (userId == null) throw new BadRequestException('userId 필수 입니다.');
+    if (Number.isNaN(userId))
+      throw new BadRequestException('userId는 숫자형만 가능합니다.');
+    if (userId < 0)
+      throw new BadRequestException('userId는 양의 정수만 가능 합니다.');
+
+    const histories = await this.historyDb.selectAllByUserId(userId);
+    return GetPointHistoryResponse.of(histories);
   }
 
   override async charge(

--- a/src/point/point.service.ts
+++ b/src/point/point.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { BadRequestException, Injectable } from '@nestjs/common';
 
 import { PointHistoryTable } from 'src/database/pointhistory.table';
 import { UserPointTable } from 'src/database/userpoint.table';
@@ -119,7 +119,14 @@ export class PointService extends PointServiceUseCase {
   }
 
   override async getPoint(userId: number): Promise<GetUserPointResponse> {
-    throw new Error('Method not implemented.');
+    if (userId == null) throw new BadRequestException('userId 필수 입니다.');
+    if (Number.isNaN(userId))
+      throw new BadRequestException('userId는 숫자형만 가능합니다.');
+    if (userId < 0)
+      throw new BadRequestException('userId는 양의 정수만 가능 합니다.');
+
+    const userPoint = await this.userDb.selectById(userId);
+    return GetUserPointResponse.of(userPoint);
   }
 
   override async getHistory(

--- a/test/point/unit/point.service.spec.ts
+++ b/test/point/unit/point.service.spec.ts
@@ -1,10 +1,16 @@
 import { type MockProxy, mock } from 'jest-mock-extended';
+import { faker } from '@faker-js/faker';
 
 import { PointService } from 'src/point/point.service';
 import { UserPointTable } from 'src/database/userpoint.table';
 import { PointHistoryTable } from 'src/database/pointhistory.table';
-import { UserPoint } from 'src/point/point.model';
+import {
+  PointHistory,
+  TransactionType,
+  UserPoint,
+} from 'src/point/point.model';
 import { BadRequestException } from '@nestjs/common';
+import { GetPointHistoryResponse } from 'src/point/dto';
 
 describe('PointService', () => {
   let userDb: MockProxy<UserPointTable>;
@@ -17,6 +23,7 @@ describe('PointService', () => {
     service = new PointService(userDb, historyDb);
   });
 
+  /** 현재 포인트 조회 */
   describe('getPoint', () => {
     it('`userId`가 존재하지 않으면(null이거나 undefined) 실패한다.', () => {
       // given
@@ -56,7 +63,7 @@ describe('PointService', () => {
       }
     });
 
-    it('`userId`가 1인 유저의 현재 포인트는 1000원이다.', async () => {
+    it('`(성공) userId`가 1인 유저의 현재 포인트는 1000원이다.', async () => {
       // given
       const userId = 1;
       const userPoint: UserPoint = {
@@ -77,9 +84,79 @@ describe('PointService', () => {
     });
   });
 
-  // describe('getHistory', () => {});
+  /** 포인트 히스토리 조회 */
+  describe('getHistory', () => {
+    it('`userId`가 존재하지 않으면(null이거나 undefined) 실패한다.', () => {
+      // given
+      const userId = null;
+
+      // when
+      const result = service.getHistory(userId);
+
+      // then
+      expect(result).rejects.toBeInstanceOf(BadRequestException);
+      expect(result).rejects.toThrow('userId 필수 입니다.');
+    });
+
+    it('`userId`가 숫자나 숫자형 문자열이 아니면 실패한다.', () => {
+      // given
+      const userId = NaN;
+
+      // when
+      const result = service.getHistory(userId);
+
+      // then
+      expect(result).rejects.toBeInstanceOf(BadRequestException);
+      expect(result).rejects.toThrow('userId는 숫자형만 가능합니다.');
+    });
+
+    it('`userId`가 양의 정수가 아니라면 실패한다.', () => {
+      // given
+      const userId = -6;
+
+      // when
+      const result = service.getHistory(userId);
+
+      // then
+      expect(result).rejects.toBeInstanceOf(BadRequestException);
+      expect(result).rejects.toThrow('userId는 양의 정수만 가능 합니다.');
+    });
+
+    it('(성공) userId`가 1인 유저의 포인트 히스토리는 3개가 존재한다.', async () => {
+      // given
+      const userId = 1;
+      const pointhistories = GetPointHistoryResponse.of(
+        createPointHistories(userId),
+      );
+      // mocking
+      historyDb.selectAllByUserId.mockResolvedValue(
+        GetPointHistoryResponse.of(pointhistories),
+      );
+
+      // when
+      const results = await service.getHistory(userId);
+      // then
+      expect(results.length).toBe(3);
+    });
+  });
 
   // describe('charge', () => {});
 
   // describe('use', () => {});
 });
+
+function createPointHistories(
+  userId: number,
+  options: { length: number } = { length: 3 },
+): PointHistory[] {
+  const randomPoint = () =>
+    faker.number.int({ min: 100, max: 1000, multipleOf: 100 });
+
+  return Array.from({ length: options.length }).map((_, i) => ({
+    id: i + 1,
+    userId,
+    type: i % 2 === 0 ? TransactionType.CHARGE : TransactionType.USE,
+    amount: randomPoint(),
+    timeMillis: Date.now(),
+  }));
+}

--- a/test/point/unit/point.service.spec.ts
+++ b/test/point/unit/point.service.spec.ts
@@ -1,0 +1,85 @@
+import { type MockProxy, mock } from 'jest-mock-extended';
+
+import { PointService } from 'src/point/point.service';
+import { UserPointTable } from 'src/database/userpoint.table';
+import { PointHistoryTable } from 'src/database/pointhistory.table';
+import { UserPoint } from 'src/point/point.model';
+import { BadRequestException } from '@nestjs/common';
+
+describe('PointService', () => {
+  let userDb: MockProxy<UserPointTable>;
+  let historyDb: MockProxy<PointHistoryTable>;
+  let service: PointService;
+
+  beforeEach(() => {
+    userDb = mock<UserPointTable>();
+    historyDb = mock<PointHistoryTable>();
+    service = new PointService(userDb, historyDb);
+  });
+
+  describe('getPoint', () => {
+    it('`userId`가 존재하지 않으면(null이거나 undefined) 실패한다.', () => {
+      // given
+      const userId = null;
+
+      // when
+      const result = service.getPoint(userId);
+
+      // then
+      expect(result).rejects.toBeInstanceOf(BadRequestException);
+      expect(result).rejects.toThrow('userId 필수 입니다.');
+    });
+
+    it('`userId`가 숫자나 숫자형 문자열이 아니면 실패한다.', () => {
+      // given
+      const userId = NaN;
+
+      // when
+      service.getPoint(userId).catch((error) => {
+        // then
+        expect(error).toBeInstanceOf(BadRequestException);
+        expect(error.message).toBe('userId는 숫자형만 가능합니다.');
+      });
+    });
+
+    it('`userId`가 양의 정수가 아니라면 실패한다.', async () => {
+      // given
+      const userId = -6;
+
+      try {
+        // when
+        await service.getPoint(userId);
+      } catch (error) {
+        // then
+        expect(error).toBeInstanceOf(BadRequestException);
+        expect(error.message).toBe('userId는 양의 정수만 가능 합니다.');
+      }
+    });
+
+    it('`userId`가 1인 유저의 현재 포인트는 1000원이다.', async () => {
+      // given
+      const userId = 1;
+      const userPoint: UserPoint = {
+        id: 1,
+        point: 1000,
+        updateMillis: Date.now(),
+      };
+
+      // mocking
+      userDb.selectById.mockResolvedValue(userPoint);
+
+      // when
+      const result = await service.getPoint(userId);
+
+      // then
+      expect(result.id).toBe(userPoint.id);
+      expect(result.point).toBe(userPoint.point);
+    });
+  });
+
+  // describe('getHistory', () => {});
+
+  // describe('charge', () => {});
+
+  // describe('use', () => {});
+});

--- a/test/point/unit/point.service.spec.ts
+++ b/test/point/unit/point.service.spec.ts
@@ -23,7 +23,24 @@ describe('PointService', () => {
     service = new PointService(userDb, historyDb);
   });
 
-  /** 현재 포인트 조회 */
+  /**
+   * 특정 유저의 포인트를 조회합니다.
+   *
+   * ### 행동 분석
+   * 1. HTTP URL Path를 통해 id(userId)를 넘겨 받는다.
+   * 2. id를 검증한다.
+   * 3. 유저의 포인트 현재 포인트를 조회한다.
+   *   - `UserPointTable#selectById` 로직에 의해 유저가 존재하지 않는 경우는 생략한다.
+   * 4. 결과에 맞게 반환한다.
+   *
+   * ### TC
+   * 1. 성공
+   * - 유저의 현재 포인트를 조회한다.
+   * - 최초에 유저의 포인트가 없다면 포인트는 0을 응답한다.
+   * 2. 실패
+   * - `userId`가 존재하지 않으면(null이거나 undefined) 실패힌다.
+   * - `userId`가 양의 정수가 아니라면 조회에 실패한다.
+   */
   describe('getPoint', () => {
     it('`userId`가 존재하지 않으면(null이거나 undefined) 실패한다.', () => {
       // given
@@ -84,7 +101,24 @@ describe('PointService', () => {
     });
   });
 
-  /** 포인트 히스토리 조회 */
+  /**
+   * 특정 유저의 포인트 충전/이용 내역을 조회합니다.
+   *
+   * ### 행동 분석
+   * 1. HTTP URL Path를 통해 id(userId)를 넘겨 받는다.
+   * 2. id를 검증한다.
+   *   - `UserPointTable#selectById` 로직에 의해 유저가 존재하지 않는 경우는 생략한다.
+   * 3. 유저의 포인트 충전/이용 내역을 조회한다.
+   * 4. 결과에 맞게 반환한다.
+   *
+   * ### TC
+   * 1. 성공
+   * - 포인트 충전/이용 내역이을 응답한다.
+   * - 포인트 충전/이용 내역이 없는 유저라면 빈 배열을 응답한다.
+   * 2. 실패
+   * - `userId`가 존재하지 않으면(null이거나 undefined) 실패힌다.
+   * - `userId`가 양의 정수가 아니라면 조회에 실패한다.
+   */
   describe('getHistory', () => {
     it('`userId`가 존재하지 않으면(null이거나 undefined) 실패한다.', () => {
       // given

--- a/test/point/unit/point.service.spec.ts
+++ b/test/point/unit/point.service.spec.ts
@@ -138,6 +138,19 @@ describe('PointService', () => {
       // then
       expect(results.length).toBe(3);
     });
+
+    it('(성공) userId`가 1인 유저의 포인트 사용내역이 없다면 빈 배열을 반환한다.', async () => {
+      // given
+      const userId = 1;
+      const pointhistories = [];
+      // mocking
+      historyDb.selectAllByUserId.mockResolvedValue(pointhistories);
+
+      // when
+      const results = await service.getHistory(userId);
+      // then
+      expect(results.length).toBe(0);
+    });
   });
 
   // describe('charge', () => {});


### PR DESCRIPTION
# PR Summery

## ✓ PR 타입
- [x] 기능 추가 & 테스트 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타

## 1️⃣ 작업내용
> [!NOTE] 구체적인 작업 내용을 정리하면 좋습니다.

1. `./test/point/unit/point.service.spec.ts` 테스트 신규 생성 
   - 포인트 조회 테스트 정의
   - 포인트 내역 조회 테스트 정의
2. 테스트 통과를 위한 포인트 조회(`PointService#getPoint`) 로직 구현
3. 테스트 통과를 위한 포인트 내역 조회(`PointService#getHistory`) 로직 구현

## 2️⃣ 의사결정 흐름
> [!NOTE] 구현된 코드의 근거나 배경에 대해 설명하면 좋습니다.

먼저 1주차 미션의 취지에 맞게 최대한 TDD 관점에서 코드 개발을 진행했어요. 테스트를 먼저 정의하고, 메서드가 테스트를 통과할 수 있게 기능을 정의하는 방향으로 해보았습니다.

그 과정에서 가장 고민되었던 2가지를 공유하고 싶습니다. ( 조금 긴 글입니다)
1. mock를 어디까지 해야할까?
2. request에서 넘어온 값을 Service는 어디까지 검증해야 할까?

### Q) 1. mock를 어디까지 해야할까? 
A) 결론 부터 말하면 Database 계층의 모듈 자체를 mocking하는 방향으로 진행했습니다.

제가 찾은 방법은 먼저 3가지 정도 있었습니다.
  a. TestDatabase 객체 즉, `stub`을 만든다. 
  b. 대역을 만들지 말고 테스트 마다 일관될 수 있도록 값을 초기화 한다.
  c. mocking을 진행한다.
저는 현재 미션에 취지에는 c가 부합하다고 생각하여, c로 진행했습니다.

#### a. 를 사용하지 않은 이유
a.를 진행하려면 database 모듈을 추상화 해야합니다. 그러려면 제공된 `/database` 모듈를 수정하는게 가장 부합합니다. 하지만 이번 미션은 제공된 `/database` 모듈을 수정하지 않고 진행하는 것이기 핵심이기 때문에 진행하지 않았습니다.

구현 예시) 
```
/** 기존 제공된 database 계층 클래스를 추상화한 추상 클래스 */ 
export abstract class PointHistoryTablePort { ... }

/** 기존 제공된 database 계층 클래스 */ 
export class PointHistoryTable extends PointHistoryTablePort { ... }

/** 테스트를 위해 생성한 `stub` 객체 */ 
export class TestPointHistoryTable extends PointHistoryTablePort { ... }

// point.service.spec.ts
describe('PointService', () => {
  let userDb: UserPointTablePort;           // 추상 클래스
  let historyDb: PointHistoryTablePort;   // 추상 클래스
  let service: PointService;

  beforeEach(() => {
    userDb = new TestPointHistoryTable();       // `stub` 객체 인스턴스화
    historyDb = new TestPointHistoryTable();   // `stub` 객체 인스턴스화
    service = new PointService(userDb, historyDb);
  });
});
```

#### b. 를 사용하지 않은 이유
제공된 `/database` 모듈에 b. 를 진행하려면 모든 테스트 시작 마다 database 계층 클래스를 인스턴스화 하면 됩니다. 하지만 이것은 현실적이지 못합니다. 미션을 위해 "In-memory"에서 database 영속화를 진행하는 것이기 때문입니다. 
결과적으로 Database 계층을 실제 DB로 변경한다면, 테스트 코드도 전부 변경해야 합니다. 이는 의존성을 최소화하여 진행하는 단위테스트에 적합하지 않는 방법입니다.

구현 예시)
```typescript
import { PointService } from 'src/point/point.service';
import { UserPointTable } from 'src/database/userpoint.table';
import { PointHistoryTable } from 'src/database/pointhistory.table';

describe('PointService', () => {
  let userDb: UserPointTable;
  let historyDb: PointHistoryTable;
  let service: PointService;

  beforeEach(() => {
    userDb = new UserPointTable();
    historyDb = new PointHistoryTable();
    service = new PointService(userDb, historyDb);
  });
});

```

#### c. 의 선정 이유
여러 자료를 찾아본 결과 database mocking에 대한 것은 갑론을박 있다고 생각됩니다. 
그럼에도 미션 취지와 단위 테스트라는 목적에 부합하려면 mocking은 좋은 선택이라고 생각됩니다.
추가적으로 저는 jest.mock의 사용방법이 타입이 잡히지 않고 안전하지 않다고 생각되어, 많이 사용되는 "jest-mock-extended"를 사용해 구현했습니다. 
- [jest-mock-extended 사용 참고](https://www.daleseo.com/jest-class-mocks/)

구현 예시)
```typescript
import { type MockProxy, mock } from 'jest-mock-extended';

import { PointService } from 'src/point/point.service';
import { UserPointTable } from 'src/database/userpoint.table';
import { PointHistoryTable } from 'src/database/pointhistory.table';

describe('PointService', () => {
  let userDb: MockProxy<UserPointTable>;
  let historyDb: MockProxy<PointHistoryTable>;
  let service: PointService;

  beforeEach(() => {
    userDb = mock<UserPointTable>();
    historyDb = mock<PointHistoryTable>();
    service = new PointService(userDb, historyDb);
  });
});

```

### Q) 2. request에서 넘어온 값을 Service는 어디까지 검증해야 할까?
A) 해당 문제의 결론은 아직 고민중이며, 리팩터링에서 적용할 예정입니다.

제가 정의한 계층의 책임은 아래와 같습니다.
- `Presentation` 계층은 REST API, GraphQL, CLI에 대한 요청을 처리하고, 데이터를 요청 부합한 포멧으로 응답합니다.
- `Service` 계층은 애플리케이션의 핵심 비즈니스 로직을 담당합니다.
- `dataAccess` 계층은 영속화를 담당하는 계층과 상호 호환하는 것을 담당합니다.

이것에 따른다면 HTTP 요청에서 들어온 모든 값은 Presentation 계층에서 검증되어야 할 것 같습니다.
그렇다면 서비스 계층 단위 테스트에서는 HTTP 요청의 값은 검증하지 않는게 맞는지 고민이 됩니다.

- OT에서 제공된 TDD PDF의 Service 계층 테스트 예시
<img width="1384" alt="image" src="https://github.com/user-attachments/assets/12cfe668-c016-46ca-8f05-461d347070a0">

- OT에서 제공된 TDD PDF의 Service 계층 테스트 개선
<img width="1392" alt="image" src="https://github.com/user-attachments/assets/878bb8eb-a980-42b2-9950-2074d11b7ba9">
  💡 "// 정책추가: request 에 대한 validation은 앞서 진행되어야 함" 이 의미가 Presentation 계층에게 검증을 넘긴다는 의미일까요?


## 3️⃣ 리뷰 포인트
> [!NOTE] 명확한 리뷰 포인트나, 리뷰 받고 싶은 코드를 참조하면 좋습니다.

- 커밋 흐름을 봐주셨으면 좋겠습니다.
- 테스트 케이스가 부합한지 봐주셨으면 좋겠습니다.
- 그리고 저는 단위 테스트에서는 Nestjs에서 제공하는 Test 기능을 사용하지 않고 Service 클래스를 테스트 하는 방향으로 진행했습니다.
이는 예전에 인상깊게 보았던 글에 의해 결정했습니다. 
 > 프레임워크의 Test 또한 의존성이다 이는 단위테스트에 적합하지 않을 수 있다.

## 4️⃣ 이슈
> [!NOTE] (optional) 공유하고 싶은 이슈나, 코드가 가진 문제(한계)를 알려주세요.

- Controller와 Service 연동: 
  * Service 대한 단위 테스트만 완료된 것이기 때문에 연동은 아직 하지 않았습니다.
- 구현된 메서드 리팩터링 진행: 
  * TDD에 따르면 [테스트 ->  기능구현 -> 리팩터링] 순서로 되어야 합니다. 
  * 그렇게 되면 코드 변경 사항이 너무 많아질 수 있어 단계적으로 진행해 보려합니다. 


 