### PR TITLE
Feat/포인트 추가(사용) 정책추가

### DIFF
--- a/src/common/exception/exception-type.ts
+++ b/src/common/exception/exception-type.ts
@@ -15,6 +15,8 @@ export enum ApplicationExceptionCode {
   INVALID_USER_ID = 'INVALID_USER_ID',
   /** 유효하지 않은 포인트 금액 사용시 발생하는 에러 코드 */
   INVALID_POINT_AMOUNT = 'INVALID_POINT_AMOUNT',
+  /** 포인트 한도초과 또는 잔액부족으로 명령 수행 불가시 발생하는 에러코드 */
+  CONFLICT_POINT_OPERATION_EXCEPTION = 'CONFLICT_POINT_OPERATION_EXCEPTION',
 }
 
 export const ApplicationExceptionRecord: ApplicationExceptionRecord = {
@@ -26,5 +28,10 @@ export const ApplicationExceptionRecord: ApplicationExceptionRecord = {
   [ApplicationExceptionCode.INVALID_POINT_AMOUNT]: {
     message: '포인트 금액은 0보다 커야 합니다.',
     state: 400,
+  },
+
+  [ApplicationExceptionCode.CONFLICT_POINT_OPERATION_EXCEPTION]: {
+    message: '포인트 잔액 부족 또는 충전 한도 초과입니다.',
+    state: 409,
   },
 } as const;

--- a/src/point/component/index.ts
+++ b/src/point/component/index.ts
@@ -1,0 +1,1 @@
+export * from './point-manager';

--- a/src/point/component/point-manager.ts
+++ b/src/point/component/point-manager.ts
@@ -1,0 +1,36 @@
+/**
+ * PointManager 객체
+ * - 현재는 단순하게 충전/사용이 가능한가 체크하는 기능만 있기 때문에 정적 메서드를 가진 클래스만 관리한다.
+ */
+export class PointManager {
+  static readonly MAX_POINT = 30000;
+  static readonly MIN_POINT = 0;
+
+  static addPoint(point: number, amount: number) {
+    return point + amount;
+  }
+
+  static subPoint(point: number, amount: number) {
+    return point - amount;
+  }
+
+  /**
+   * 포인트 충전 가능한지 확인하는 메서드
+   * @param currantPoint 현재 포인트
+   * @param amount 충전할 금액
+   * @returns 충전 가능 유무
+   */
+  static canChargePoint(currantPoint: number, amount: number) {
+    return currantPoint + amount < PointManager.MAX_POINT;
+  }
+
+  /**
+   * 포인트 사용 가능한지 확인하는 메서드
+   * @param currantPoint 현재 포인트
+   * @param amount 사용할 금액
+   * @returns 사용 가능 유무
+   */
+  static canUsePoint(currantPoint: number, amount: number) {
+    return currantPoint - amount > PointManager.MIN_POINT;
+  }
+}

--- a/src/point/exception/conflict-point-operation.exception.ts
+++ b/src/point/exception/conflict-point-operation.exception.ts
@@ -1,0 +1,7 @@
+import { ApplicationException, ApplicationExceptionCode } from 'src/common';
+
+export class ConflictPointOperationException extends ApplicationException {
+  constructor() {
+    super(ApplicationExceptionCode.CONFLICT_POINT_OPERATION_EXCEPTION);
+  }
+}

--- a/src/point/exception/index.ts
+++ b/src/point/exception/index.ts
@@ -1,2 +1,3 @@
 export * from './invalid-user-id.exception';
 export * from './invalid-point-amount.exception';
+export * from './conflict-point-operation.exception';

--- a/src/point/point.module.ts
+++ b/src/point/point.module.ts
@@ -1,11 +1,15 @@
 import { Module } from '@nestjs/common';
-import { PointController } from './point.controller';
 import { DatabaseModule } from 'src/database/database.module';
+import { PointController } from './point.controller';
+import { PointRepository, PointRepositoryPort } from './point.repository';
 import { PointService, PointServiceUseCase } from './point.service';
 
 @Module({
   imports: [DatabaseModule],
   controllers: [PointController],
-  providers: [{ provide: PointServiceUseCase, useClass: PointService }],
+  providers: [
+    { provide: PointServiceUseCase, useClass: PointService },
+    { provide: PointRepositoryPort, useClass: PointRepository },
+  ],
 })
 export class PointModule {}

--- a/src/point/point.repository.ts
+++ b/src/point/point.repository.ts
@@ -1,0 +1,52 @@
+import { PointHistoryTable } from 'src/database/pointhistory.table';
+import { UserPointTable } from 'src/database/userpoint.table';
+import { PointHistory, UserPoint } from './point.model';
+
+type InsertPointBody = Pick<PointHistory, 'amount' | 'type'>;
+
+export abstract class PointRepositoryPort {
+  abstract findPointBy(userId: number): Promise<UserPoint>;
+
+  abstract findHistoriesBy(userId: number): Promise<PointHistory[]>;
+
+  /**
+   * 포인트 생성 트랜잭션
+   * - PointHistory를 생성한다.
+   * - UserPoint를 최신화 한다.
+   * @param userId
+   * @param body
+   */
+  abstract insertPointWithTransaction(
+    userId: number,
+    body: InsertPointBody,
+  ): Promise<UserPoint>;
+}
+
+export class PointRepository extends PointRepositoryPort {
+  constructor(
+    private readonly userDb: UserPointTable,
+    private readonly historyDb: PointHistoryTable,
+  ) {
+    super();
+  }
+
+  override async findPointBy(userId: number): Promise<UserPoint> {
+    return await this.userDb.selectById(userId);
+  }
+
+  override async findHistoriesBy(userId: number): Promise<PointHistory[]> {
+    return await this.historyDb.selectAllByUserId(userId);
+  }
+
+  override async insertPointWithTransaction(
+    userId: number,
+    body: InsertPointBody,
+  ): Promise<UserPoint> {
+    const { amount, type } = body;
+    await this.historyDb.insert(userId, amount, type, Date.now());
+    const userPoint = await this.userDb.selectById(userId);
+
+    const updatePoint = userPoint.point + amount;
+    return await this.userDb.insertOrUpdate(userId, updatePoint);
+  }
+}

--- a/src/point/point.service.ts
+++ b/src/point/point.service.ts
@@ -1,7 +1,5 @@
 import { Injectable } from '@nestjs/common';
 
-import { PointHistoryTable } from 'src/database/pointhistory.table';
-import { UserPointTable } from 'src/database/userpoint.table';
 import {
   GetPointHistoryResponse,
   GetUserPointResponse,
@@ -13,14 +11,7 @@ import {
 } from './exception';
 
 import { TransactionType } from './point.model';
-
-/*
-  TODO: 리펙터링
-  1. userId 검증은 어떻게 할까? 
-    - 그냥 컨트롤러 Pipe로 해결
-    - param Valdate 정의?
-    - 
-*/
+import { PointRepositoryPort } from './point.repository';
 
 export abstract class PointServiceUseCase {
   /**
@@ -60,19 +51,14 @@ export abstract class PointServiceUseCase {
 
 @Injectable()
 export class PointService extends PointServiceUseCase {
-  readonly list = {};
-
-  constructor(
-    private readonly userDb: UserPointTable,
-    private readonly historyDb: PointHistoryTable,
-  ) {
+  constructor(private readonly pointRepo: PointRepositoryPort) {
     super();
   }
 
   override async getPoint(userId: number): Promise<GetUserPointResponse> {
     if (userId < 0) throw new InvalidUserIdException();
 
-    const userPoint = await this.userDb.selectById(userId);
+    const userPoint = await this.pointRepo.findPointBy(userId);
     return GetUserPointResponse.of(userPoint);
   }
 
@@ -80,8 +66,7 @@ export class PointService extends PointServiceUseCase {
     userId: number,
   ): Promise<GetPointHistoryResponse[]> {
     if (userId < 0) throw new InvalidUserIdException();
-
-    const histories = await this.historyDb.selectAllByUserId(userId);
+    const histories = await this.pointRepo.findHistoriesBy(userId);
     return GetPointHistoryResponse.of(histories);
   }
 
@@ -92,16 +77,12 @@ export class PointService extends PointServiceUseCase {
     if (userId < 0) throw new InvalidUserIdException();
     if (pointDto.amount < 0) throw new InvalidPointAmountException();
 
-    await this.historyDb.insert(
-      userId,
-      pointDto.amount,
-      TransactionType.CHARGE,
-      Date.now(),
-    );
-
-    const userPoint = await this.userDb.selectById(userId);
-    const updatePoint = userPoint.point + pointDto.amount;
-    const result = await this.userDb.insertOrUpdate(userId, updatePoint);
+    const { point: currantPoint } = await this.pointRepo.findPointBy(userId);
+    const result = await this.pointRepo.insertPointWithTransaction(userId, {
+      point: currantPoint + pointDto.amount,
+      amount: pointDto.amount,
+      type: TransactionType.CHARGE,
+    });
     return GetUserPointResponse.of(result);
   }
 
@@ -112,16 +93,12 @@ export class PointService extends PointServiceUseCase {
     if (userId < 0) throw new InvalidUserIdException();
     if (pointDto.amount < 0) throw new InvalidPointAmountException();
 
-    await this.historyDb.insert(
-      userId,
-      pointDto.amount,
-      TransactionType.USE,
-      Date.now(),
-    );
-
-    const userPoint = await this.userDb.selectById(userId);
-    const updatePoint = userPoint.point - pointDto.amount;
-    const result = await this.userDb.insertOrUpdate(userId, updatePoint);
+    const { point: currantPoint } = await this.pointRepo.findPointBy(userId);
+    const result = await this.pointRepo.insertPointWithTransaction(userId, {
+      point: currantPoint - pointDto.amount,
+      amount: pointDto.amount,
+      type: TransactionType.USE,
+    });
     return GetUserPointResponse.of(result);
   }
 }

--- a/test/point/unit/point.service.spec.ts
+++ b/test/point/unit/point.service.spec.ts
@@ -166,6 +166,25 @@ describe('PointService', () => {
         // then
         expect(promiseResult).rejects.toBeInstanceOf(success);
       });
+
+      it('충전 한도에 초과하면 실패한다.', () => {
+        // given
+        const userId = 1;
+        const defaultPoint = PointManager.MAX_POINT;
+        const chargeAmount = 1000;
+        const success = ConflictPointOperationException;
+
+        pointRepo.findPointBy.mockResolvedValue({
+          id: userId,
+          point: defaultPoint,
+          updateMillis: Date.now() - 60000,
+        });
+
+        // when
+        const promiseResult = service.charge(userId, { amount: chargeAmount });
+        // then
+        expect(promiseResult).rejects.toBeInstanceOf(success);
+      });
     });
 
     describe('성공한다.', () => {
@@ -231,6 +250,25 @@ describe('PointService', () => {
 
         // when
         const promiseResult = service.use(userId, pointDto);
+        // then
+        expect(promiseResult).rejects.toBeInstanceOf(success);
+      });
+
+      it('잔액부족이면 사용에 실패한다.', () => {
+        // given
+        const userId = 1;
+        const defaultPoint = PointManager.MIN_POINT;
+        const useAmount = 1000;
+        const success = ConflictPointOperationException;
+
+        pointRepo.findPointBy.mockResolvedValue({
+          id: userId,
+          point: defaultPoint,
+          updateMillis: Date.now() - 60000,
+        });
+
+        // when
+        const promiseResult = service.use(userId, { amount: useAmount });
         // then
         expect(promiseResult).rejects.toBeInstanceOf(success);
       });


### PR DESCRIPTION
# PR Summery

## ✓ PR 타입
- [x] 기능 추가(테스트 추가)
- [x] 기능 개선(테스트 개선)
- [ ] 기능 삭제(테스트 삭제)
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타

## 1️⃣ 작업내용
> [!NOTE] 
> 구체적인 작업 내용을 정리하면 좋습니다.

1. Repository 개층 추가
  - `PointRepository` 신규 생성 
  - `PointService` 기존 Database 모듈 직접 의존 로직에서 신규 생성한 Repository를 의존하도록 변경
  - 기존 테스트 코드 의존성 Mock 로직 수정
    
2. 포인트 사용, 포인트 충전 로직 신규 정책 추가
  - 정책을 관리하는 PointManager 신규 추가
  - 정책에 위반하는 경우 처리할 예외 신규 추가: `ConflictPointOperationException`
  - `PointService#charge`에 정책 관리하는 로직 추가
  - `PointService#use`에 정책 관리하는 로직 추가
  - 기존 테스트 코드에 신규 정책을 위반하는 경우에 대한 실패 테스트 케이스 추가 


## 2️⃣ 의사결정 흐름
> [!NOTE] 구현된 코드의 근거나 배경에 대해 설명하면 좋습니다.

### Case4를 사용한 Repository 계층 추가에서 느낀 문제점
<img width="1412" alt="image" src="https://github.com/user-attachments/assets/fb4b7a28-b08f-435f-bfb5-9aa1d65df3e3">

`PointRepository`를 추가하면서 평소 자주사용하는 **Case4**를 적용하려 했습니다.
Domain 객체도 선언하고, Mapper도 선언하고, 빠르게 PointRepository를 만들어 Service 로직에 의존성을 연결했습니다.
평소였으면 여기서 만족하고 테스트 후 PR을 올렸을거 같습니다. 하지만 이번에는 기존에 작성한 테스트를 수정해야하는 작업이 더 남았습니다.

기존 테스트를 수정하려는데 뭔가 잘못되었음을 느꼈습니다.
테스트에서 기존 Database 모듈을 mock 하는 코드만 Repository로 변경하는 작업이 아닌 
대부분의 코드에 리턴 값을 Domain 객체로 변경해야했기 때문입니다. 테스트 코드는 의존성 변경에 유연하게 만들어야 하는데 대부분의 코드가 망가진거죠. 그래서 작업한 코드를 되돌리고 다시 한 번 고민을 했습니다. 

### Q) 어떻게 해야 의존성 변경을 유연하게 처리 할 수 있을까?


```typescript
// 구현했던 도메인 객체 예시
import { UserPoint } from './point.model';

type UserPointDomainProp = UserPoint;

export class UserPointDomain {
  static readonly MAX_POINT = 30000;
  static readonly MIN_POINT = 0;

  constructor(private readonly prop: UserPointDomainProp) {}

  get id(): number {
    return this.prop.id;
  }

  get point(): number {
    return this.prop.point;
  }

  get updateMillis(): number {
    return this.prop.updateMillis;
  }

  canChargePoint(amount: number) {
    return this.point + amount < UserPointDomain.MAX_POINT;
  }

  canUsePoint(amount: number) {
    return this.point - amount > UserPointDomain.MIN_POINT;
  }
}

```
먼저 Case4를 쓴 이유를 다시 생각해보기로 합니다.
1. Entity와 서비스에서 사용하는 객체 분리
2. 추가된 정책을 Domain 로직에 담아서 관리

이번에는 1번 이유보단 2번째가 주된 이유 였습니다. 그렇다면 2번의 역할을 수행하는 객체를 따로 만들고 싶었습니다.
어떻게 할까? 고민하던중 발제에서 말하셨던 **"책임을 위임한 Component를 만들어 해결"**하는 방법이 생각났습니다.

<img width="1393" alt="image" src="https://github.com/user-attachments/assets/e6d35653-9f5c-45b9-8a8b-5cb2e1dc05dd">

처음 시도에는 그대로 만들어 볼까 했으나, Service가 아닌 Component에서 Repository를 직접 의존하는 방식에서 Service도 Repository를 의존하고, Component도 Repository를 의존하는 상황이 생겼습니다. 이해도가 낮은 상태에서 직접 사용하고 응용하는 것은 어렵다고 판단해 Component가 Repository를 의존하는 방향은 배제했습니다.

대신 가벼운 방법인 정적 메서드를 들고 있는 클래스를 선언해 사용하기로 결정합니다.
그리고 결과적으로 테스트 코드는 "기존 Database 모듈을 mock 하는 코드만 Repository로 변경하는 작업"만으로 정상 동작하게 됩니다.

```typescript
export class PointManager {
  static readonly MAX_POINT = 30000;
  static readonly MIN_POINT = 0;

  static addPoint(point: number, amount: number) {
    return point + amount;
  }

  static subPoint(point: number, amount: number) {
    return point - amount;
  }

  /**
   * 포인트 충전 가능한지 확인하는 메서드
   * @param currantPoint 현재 포인트
   * @param amount 충전할 금액
   * @returns 충전 가능 유무
   */
  static canChargePoint(currantPoint: number, amount: number) {
    return currantPoint + amount < PointManager.MAX_POINT;
  }

  /**
   * 포인트 사용 가능한지 확인하는 메서드
   * @param currantPoint 현재 포인트
   * @param amount 사용할 금액
   * @returns 사용 가능 유무
   */
  static canUsePoint(currantPoint: number, amount: number) {
    return currantPoint - amount > PointManager.MIN_POINT;
  }
}

// PointManager를 사용하는 PointServiceUseCase#charge
export abstract class PointServiceUseCase {
  ... 생략
  override async charge(
    userId: number,
    pointDto: PatchPointRequest,
  ): Promise<GetUserPointResponse> {
    if (userId < 0) throw new InvalidUserIdException();
    if (pointDto.amount < 0) throw new InvalidPointAmountException();

    const { point: currantPoint } = await this.pointRepo.findPointBy(userId);
    if (!PointManager.canChargePoint(currantPoint, pointDto.amount)) {
      throw new ConflictPointOperationException();
    }

    const point = PointManager.addPoint(currantPoint, pointDto.amount);
    const result = await this.pointRepo.insertPointWithTransaction(userId, {
      point,
      amount: pointDto.amount,
      type: TransactionType.CHARGE,
    });
    return GetUserPointResponse.of(result);
  }
  ... 생략
}
```
 
## 3️⃣ 리뷰 포인트
> [!NOTE] 명확한 리뷰 포인트나, 리뷰 받고 싶은 코드를 참조하면 좋습니다.

- 신규 정책이 추가된 서비스 로직과 테스트 코드를 봐주시면 좋겠습니다.

## 4️⃣ 이슈
> [!NOTE] (optional) 공유하고 싶은 이슈나, 코드가 가진 문제(한계)를 알려주세요.

- Case4가 아닌 Case2로 진행했습니다. 
- 가장 해보고 싶은 방법은 Case3 이지만, 아직까지 코드에서 어떻게 사용해야할지 정확하게는 모르겠어서 더 고민해볼 부분입니다.

 